### PR TITLE
travis: Deploy only from 1.4.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: go
 go:
-- '1.0'
-- '1.3'
+- 1.4.1
 deploy:
   provider: heroku
   api_key:
     secure: NC8jvWAqe8lQBUhkyZZQJiGpYNjU+JmQswIY7IsOD3oyOvfrIAVPLwghw52ZtezslvJ4/Ab4JD1wHY51BUoeWr71NysEN7vt5kFe2G1XIIaCNfLv9tP+3uLDGmEcJLT8YxubUG2BRJTlTxr5Ogco/P6n8oHJJBS7p5N03fK4IHQ=
   app: www-gentoo-gr-jp
   on:
+    go: 1.4.1
     repo: gentoojp/www-gentoo-gr-jp-redirector


### PR DESCRIPTION
@kjmkznr 

travisでデプロイするようになっていたのでコメントです。
- Go 1.0で試験している特別な理由はありますか？
- 1.4.1のみにしてみました (https://travis-ci.org/gentoojp/www-gentoo-gr-jp-redirector/jobs/50336868 みるとbuildpackは1.4みたいなので)
- http://blog.travis-ci.com/2013-07-09-introducing-continuous-deployment-to-heroku/ を参考に1.4.1でのテスト成功時のみデプロイするようにしてみました
